### PR TITLE
A simple web app using FastAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+__pycache__/
+
+venv/
+.env

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,31 @@
+CommCare FHIR Web App
+=====================
+
+A reference implementation of a web application that integrates with
+CommCare using FHIR
+
+
+Running in a development environment
+------------------------------------
+
+Requires Python 3.9+.
+
+1. Create a virtual environment::
+
+       $ python3.9 -m venv venv
+       $ source venv/bin/activate
+
+2. Install requirements::
+
+       $ pip install -r requirements.txt
+
+3. Configure environment variables::
+
+       $ cp _env_example .env
+       $ $EDITOR .env    # (where $EDITOR is your favorite editor)
+       $ source .env
+
+4. Run the development web server::
+
+       $ uvicorn web_app.main:app --reload
+

--- a/_env_example
+++ b/_env_example
@@ -1,0 +1,4 @@
+export CCHQ_BASE_URL=https://www.commcarehq.org/
+export CCHQ_PROJECT_SPACE=example
+export CCHQ_USERNAME=admin@example.com
+export CCHQ_API_KEY=s3cr3t

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn[standard]
 jinja2
+aiohttp
+aiodns

--- a/templates/patient.html
+++ b/templates/patient.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>CommCare HQ FHIR Patient</title>
+</head>
+<body>
+  <table>
+    <tr>
+      <th>Name:</th>
+      <td>Alice Apple</td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/templates/patient.html
+++ b/templates/patient.html
@@ -1,13 +1,97 @@
+<!doctype html>
 <html>
 <head>
   <title>CommCare HQ FHIR Patient</title>
+  <style>
+  h1 {
+    font-family: sans;
+  }
+
+  th {
+    background: gray;
+    color: white;
+    padding: 0.5em;
+  }
+  </style>
 </head>
 <body>
+  <h1>CommCare HQ FHIR Patient</h1>
+
+  {% if not patient %}
+  <p>Patient not found</p>
+  {% else %}
   <table>
-    <tr>
-      <th>Name:</th>
-      <td>Alice Apple</td>
-    </tr>
+      <tr>
+        <th colspan="2">
+          Patient
+        </th>
+      </tr>
+
+      <tr>
+        <td>Name:</td>
+        <td>{{ patient['name'][0]['text'] }}</td>
+      </tr>
+      <tr>
+        <td>Date of birth:</td>
+        <td>{{ patient['birthDate'] }}</td>
+      </tr>
+      <tr>
+        <td colspan="2">&nbsp;</td>
+      </tr>
+
+      {% if observations %}
+      <tr>
+        <th colspan="2">
+          Observations
+        </th>
+      </tr>
+
+      {% for obs in observations %}
+      <tr>
+        <td>Code:</td>
+        <td>{{ obs['code']['coding'][0]['display'] }}</td>
+      </tr>
+      <tr>
+        <td>Value:</td>
+        <td>
+          {{ obs['valueQuantity']['value'] }}
+          {{ obs['valueQuantity']['unit'] }}
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">&nbsp;</td>
+      </tr>
+      {% endfor %}
+      {% endif %}
+
+      {% if diag_reports %}
+      <tr>
+        <th colspan="2">
+          Diagnostic Reports
+        </th>
+      </tr>
+
+      {% for rep in diag_reports %}
+      <tr>
+        <td>Code:</td>
+        <td>{{ rep['code']['coding'][0]['display'] }}</td>
+      </tr>
+      <tr>
+        <td>Conclusion:</td>
+        <td>
+          {{ rep['conclusion'] }}
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">&nbsp;</td>
+      </tr>
+      {% endfor %}
+      {% endif %}
   </table>
+  {% endif %}
+
+  <p>
+    <a href="/"><button>Back</button></a>
+  </p>
 </body>
 </html>

--- a/templates/root.html
+++ b/templates/root.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <title>CommCare HQ FHIR Patient</title>
+</head>
+<body>
+  <form action="patient/" method="GET">
+    <p>
+      <label for="patient_id">Patient ID:</label>
+      <input id="patient_id" name="patient_id" type="text" />
+    </p>
+    <p>
+      <input name="submit"
+             type="submit"
+             value="Submit" />
+    </p>
+  </form>
+</body>
+</html>

--- a/templates/root.html
+++ b/templates/root.html
@@ -1,8 +1,16 @@
+<!doctype html>
 <html>
 <head>
   <title>CommCare HQ FHIR Patient</title>
+  <style>
+  h1 {
+    font-family: sans;
+  }
+  </style>
 </head>
 <body>
+  <h1>CommCare HQ FHIR Patient</h1>
+
   <form action="patient/" method="GET">
     <p>
       <label for="patient_id">Patient ID:</label>

--- a/web_app/fhir_client.py
+++ b/web_app/fhir_client.py
@@ -1,2 +1,59 @@
-async def fetch_patient(patient_id):
-    return {}  # TODO: Fetch FHIR Patient
+import asyncio
+import logging
+from typing import Optional
+
+import aiohttp
+
+from web_app.http import auth_header, base_url, slash_join
+
+
+async def fetch_patient_data(patient_id):
+    """
+    Fetches a Patient resource, and Observation and DiagnosticReport
+    resources filtered by the Patient's ID.
+    """
+    async with aiohttp.ClientSession() as session:
+        patient, observations, diag_reports = await asyncio.gather(
+            fetch_resource(session, 'Patient', patient_id),
+            search_resources(session, 'Observation', patient_id),
+            search_resources(session, 'DiagnosticReport', patient_id),
+        )
+        return patient, observations, diag_reports
+
+
+async def fetch_resource(session, resource_type, resource_id):
+    """
+    Fetches a single resource.
+    """
+    url = slash_join(base_url(), f'/{resource_type}/{resource_id}/')
+    return await fetch_json(session, url)
+
+
+async def search_resources(session, resource_type, patient_id):
+    """
+    Search resources of ``resource_type`` by ``patient_id``
+    """
+    url = slash_join(base_url(), f'/{resource_type}/')
+    params = {'patient_id': patient_id}
+    async with session.get(url, params=params, headers=auth_header()) as resp:
+        if resp.status != 200:
+            text = await resp.text()
+            logging.warning(f'URL: {url}: {resp.status}: {text}')
+            return None
+        searchset_bundle = await resp.json()
+        urls = (e['fullUrl'] for e in searchset_bundle['entry'])
+        coroutines = (fetch_json(session, u) for u in urls)
+        return await asyncio.gather(*coroutines)
+
+
+async def fetch_json(session, url) -> Optional[dict]:
+    """
+    Sends a GET request to ``url`` and returns the response JSON as a
+    ``dict``. If the response status code is not 200, returns ``None``.
+    """
+    async with session.get(url, headers=auth_header()) as resp:
+        if resp.status != 200:
+            text = await resp.text()
+            logging.warning(f'URL: {url}: {resp.status}: {text}')
+            return None
+        return await resp.json()

--- a/web_app/fhir_client.py
+++ b/web_app/fhir_client.py
@@ -1,0 +1,2 @@
+async def fetch_patient(patient_id):
+    return {}  # TODO: Fetch FHIR Patient

--- a/web_app/http.py
+++ b/web_app/http.py
@@ -1,0 +1,34 @@
+import os
+
+
+def slash_join(*args: str) -> str:
+    """
+    Joins ``args`` with a single "/"
+
+    >>> slash_join('http://example.com', 'a/', '/foo/')
+    'http://example.com/a/foo/'
+
+    """
+    if not args:
+        return ''
+    append_slash = args[-1].endswith('/')
+    url = '/'.join([arg.strip('/') for arg in args])
+    return url + '/' if append_slash else url
+
+
+def base_url() -> str:
+    """
+    Returns the FHIR API base URL based on environment variables.
+    """
+    https_commcarehq_org = os.environ['CCHQ_BASE_URL']
+    proj = os.environ['CCHQ_PROJECT_SPACE']
+    return slash_join(https_commcarehq_org, f'/a/{proj}/fhir/R4/')
+
+
+def auth_header() -> dict:
+    """
+    Returns the API Key auth header based on environment variables.
+    """
+    username = os.environ['CCHQ_USERNAME']
+    api_key = os.environ['CCHQ_API_KEY']
+    return {'Authorization': f'ApiKey {username}:{api_key}'}

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1,8 +1,25 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 
-app = FastAPI()
+from web_app.fhir_client import fetch_patient
+
+app = FastAPI(default_response_class=HTMLResponse)
+templates = Jinja2Templates(directory="templates")
 
 
 @app.get("/")
-async def root():
-    return {"message": "Hello World"}
+async def root(request: Request):
+    return templates.TemplateResponse("root.html", {
+        'request': request,
+    })
+
+
+@app.get("/patient/")
+async def view_patient(request: Request):
+    patient_id = request.query_params['patient_id']
+    patient = await fetch_patient(patient_id)
+    return templates.TemplateResponse("patient.html", {
+        'request': request,
+        'patient': patient,
+    })

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from web_app.fhir_client import fetch_patient
+from web_app.fhir_client import fetch_patient_data
 
 app = FastAPI(default_response_class=HTMLResponse)
 templates = Jinja2Templates(directory="templates")
@@ -18,8 +18,10 @@ async def root(request: Request):
 @app.get("/patient/")
 async def view_patient(request: Request):
     patient_id = request.query_params['patient_id']
-    patient = await fetch_patient(patient_id)
+    patient, observations, diag_reports = await fetch_patient_data(patient_id)
     return templates.TemplateResponse("patient.html", {
         'request': request,
         'patient': patient,
+        'observations': observations,
+        'diag_reports': diag_reports,
     })


### PR DESCRIPTION
This web app demonstrates how to use CommCareHQ's FHIR API.

This [FastAPI](https://fastapi.tiangolo.com/) version is exactly the same as the Flask web app featured in PR #2, but API requests are made concurrently. FastAPI is like Flask in its simplicity, but designed for Python 3.6+.

The pertinent code is in the **fhir_client** module.

The app uses a bare-bones UI to show data about a patient and their related FHIR resources:
![image](https://user-images.githubusercontent.com/708421/116335969-05fa5b00-a7d8-11eb-92e6-0e1de1ca6ba4.png)
